### PR TITLE
Drop the custom katip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .stack-work
+*~
+*.swp

--- a/src/Control/Logger/Katip.hs
+++ b/src/Control/Logger/Katip.hs
@@ -5,7 +5,7 @@ module Control.Logger.Katip
   ( logSeverityToKSeverity
   , KatipContextTState(..)
   , getKatipLogger
-  , ourFormatter
+  , ourItemJson
   , katipIndexNameString
   ) where
 
@@ -14,12 +14,11 @@ import           Control.Has.Katip ()
 import           Control.Lens hiding ((.=))
 import           Control.Logger.Internal
 import           Data.Aeson hiding (Error)
-import qualified Data.HashMap.Strict as HM
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy.Builder as T.Builder
 import           Katip as K hiding (logMsg)
-import           Katip.Core (ItemFunc(..), LocJs(..), ProcessIDJs(..))
+import           Katip.Core (LocJs(..), ProcessIDJs(..))
 import           Katip.Monadic (KatipContextTState(..))
 
 
@@ -30,24 +29,6 @@ logSeverityToKSeverity = \case
   Warn -> WarningS
   Error  -> ErrorS
 
-
--- | Adds the @rev-hash@ value to each record.
--- Early we copied `msg` to `msg-keyword` here but drop it
--- because purpose of this duplication is not clear.
-ourFormatter
-  :: Text
-  -- ^ git revision string
-  -> Verbosity
-  -> ItemFunc Value
-ourFormatter gitRev verb = ItemFunc $ \item -> go $ ourItemJson verb item
-  where
-    go :: Value -> Value
-    go = \case
-      Object h -> Object $ setRev h
-      x        -> x -- drop exception here?
-      where
-        setRev :: HM.HashMap Text Value -> HM.HashMap Text Value
-        setRev = HM.insert "rev-hash" (toJSON gitRev)
 
 katipIndexNameString :: Text
 katipIndexNameString = "antorica-b2b-logs"

--- a/src/Control/Logger/Katip/Utils.hs
+++ b/src/Control/Logger/Katip/Utils.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE CPP #-}
 
 module Control.Logger.Katip.Utils
   ( katipIndexNameString
@@ -6,7 +7,6 @@ module Control.Logger.Katip.Utils
   , LogFormat(..)
   , registerFileScribe
   , setLoggingCtx
-  , ourFormatter
   , getKatipLogger
   , logSeverityToKSeverity
   ) where
@@ -20,17 +20,35 @@ import           Control.Logger.Internal as L
 import           Control.Logger.Katip as L
 import           Data.Aeson hiding (Error)
 import           Data.Aeson.Text
-import qualified Data.ByteString.Builder as B.Builder
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.KeyMap as HM
+import qualified Data.Aeson.Key as HM
+#else
 import qualified Data.HashMap.Strict as HM
+#endif
 import           Data.Text (Text)
+import qualified Data.Text.Lazy as T
 import qualified Data.Text.Lazy.Builder as T.Builder
-import qualified Data.Text.Lazy.Encoding as T.Lazy
 import           Katip as K hiding (logMsg)
-import           Katip.Core (ItemFunc(..))
 import           Katip.Monadic (KatipContextTState(..))
 import qualified Katip.Scribes.Handle as K
 import           System.IO
 
+
+#if MIN_VERSION_aeson(2,0,0)
+type KeyMap v = HM.KeyMap v
+textToKey :: Text -> Key
+textToKey = HM.fromText
+keyToText :: Key -> Text
+keyToText = HM.toText
+#else
+type KeyMap v = HM.HashMap Text v
+type Key = Text
+textToKey :: Text -> Key
+textToKey = id
+keyToText :: Key -> Text
+keyToText = id
+#endif
 
 -- | How to format logs
 data LogFormat
@@ -55,38 +73,42 @@ registerFileScribe gitRev verbosity format filePath permitF additions logenv =
     formatter = case format of
       LogBracket -> customBracketFormat additions'
       LogJson    -> customJsonFormat gitRev additions'
-    additions' = HM.fromList . map (fmap String) $ additions
+    additions'
+      = HM.fromList
+      . map (\(k, v) -> (textToKey k, String v))
+      $ additions
 
 -- | JSON formatter that adds the specified fields to the output
 customJsonFormat
-  :: forall a. LogItem a => Text -> HM.HashMap Text Value -> ItemFormatter a
+  :: forall a. LogItem a => Text -> KeyMap Value -> ItemFormatter a
 customJsonFormat gitRev additions withColor verb i = (mappend "\n") $
   -- Here we reimplement the standard formater because we want the
   -- additional key/value pairs to be added at the top level.
   -- So we can't use the LogWithAdditions like we do for bracket format
-  B.Builder.lazyByteString . T.Lazy.encodeUtf8 . T.Builder.toLazyText $
+  T.Builder.fromText $
     K.colorBySeverity withColor (_itemSeverity i) $
-      encodeToTextBuilder (extend $ applyItemFunc (ourFormatter gitRev verb) i)
+      (T.toStrict . encodeToLazyText) (extend $ ourItemJson verb i)
   where
-    extend (Object o) = Object $ HM.union additions o
+    extend (Object o) = Object $ HM.union additions' o
     extend v          = v
+    additions' = HM.insert "rev-hash" (toJSON gitRev) additions
 
 -- | Bracket formatter that adds the specified fields to the output
 customBracketFormat
-  :: forall a. LogItem a => HM.HashMap Text Value -> ItemFormatter a
+  :: forall a. LogItem a => KeyMap Value -> ItemFormatter a
 customBracketFormat additions withColor verb i =
   bracketFormat withColor verb (LogWithAdditions additions <$> i)
 
 -- | Log item payload that adds the specified additional key/value pairs
 -- to the output on at verbosity levels
-data LogWithAdditions a = LogWithAdditions (HM.HashMap Text Value) a
+data LogWithAdditions a = LogWithAdditions (KeyMap Value) a
   deriving (Show)
 
 instance LogItem a => LogItem (LogWithAdditions a) where
   payloadKeys v (LogWithAdditions additions a) =
     case payloadKeys v a of
       AllKeys       -> AllKeys
-      SomeKeys keys -> SomeKeys (HM.keys additions ++ keys)
+      SomeKeys keys -> SomeKeys (map keyToText (HM.keys additions) ++ keys)
 
 instance ToObject a => ToObject (LogWithAdditions a) where
   toObject (LogWithAdditions additions a) =


### PR DESCRIPTION
Now it compiles both with ghc-8 and ghc-9 and uses the released version of katip