### PR TITLE
Allow log censoring

### DIFF
--- a/control-logger.cabal
+++ b/control-logger.cabal
@@ -31,7 +31,7 @@ library
                      , time
                      , unordered-containers
   if !impl(ghcjs)
-    build-depends:     katip
+    build-depends:     katip >= 0.8.8.0
                      , optparse-applicative
   default-language:    Haskell2010
   default-extensions:  RankNTypes

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.ghc
+    pkgs.haskellPackages.cabal-install
+    pkgs.zlib
+  ];
+}

--- a/src/Control/Logger.hs
+++ b/src/Control/Logger.hs
@@ -2,6 +2,7 @@
 module Control.Logger
   ( Logger
   , loggerContext
+  , scrubber
   , logMsg
   , logMsgWith
   , logInfo

--- a/src/Control/Logger/Internal.hs
+++ b/src/Control/Logger/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE CPP #-}
 
 module Control.Logger.Internal
@@ -18,6 +19,7 @@ import Control.Lens
 import Control.DeepSeq
 import Data.Aeson (ToJSON, FromJSON, Object)
 import Data.Text (Text)
+import Data.Monoid
 import GHC.Stack
 #if MIN_VERSION_mtl(2,3,0)
 import Control.Monad.IO.Class
@@ -34,25 +36,26 @@ data LogSeverity
 instance ToJSON LogSeverity
 instance FromJSON LogSeverity
 
-data Logger
-  = Logger
+data Logger = Logger
   { _loggerContext :: Object
-  , _scrubber :: Text -> Text
+  , _scrubber :: Endo Text
   , _loggerAction  :: Object -> CallStack -> LogSeverity -> Text -> IO ()
   } deriving Generic
 
-instance NFData Logger
+instance NFData Logger where
+  rnf Logger{_loggerContext, _scrubber, _loggerAction} =
+    rnf _loggerContext `deepseq` rwhnf (appEndo _scrubber) `deepseq` rwhnf _loggerAction
 
 makeLenses ''Logger
 
 instance Semigroup Logger where
   (Logger ctx1 s1 l1) <> (Logger ctx2 s2 l2)
-    = Logger ctx' (s1 . s2)
+    = Logger ctx' (s1 <> s2)
     $ \ctx stack s t -> l1 ctx stack s t >> l2 ctx stack s t
     where ctx' = ctx1 <> ctx2
 
 instance Monoid Logger where
-  mempty = Logger mempty id $ \_ _ _ _ -> pure ()
+  mempty = Logger mempty mempty $ \_ _ _ _ -> pure ()
 
 type LoggingMonad r m =
   (MonadReader r m, Has Logger r, MonadIO m, HasCallStack)
@@ -76,4 +79,4 @@ logMsgWith logger s t =
   liftIO $ runLogger logger callStack s t
 
 runLogger :: Logger -> CallStack -> LogSeverity -> Text -> IO ()
-runLogger (Logger ctx scrubber logger) cs ls txt = logger ctx cs ls (scrubber txt)
+runLogger (Logger ctx theScrubber logger) cs ls txt = logger ctx cs ls (appEndo theScrubber txt)

--- a/src/Control/Logger/Katip.hs
+++ b/src/Control/Logger/Katip.hs
@@ -56,7 +56,7 @@ instance LogItem Object where
   payloadKeys _ _  = AllKeys
 
 getKatipLogger :: KatipContextTState -> Logger
-getKatipLogger katipCtx = Logger (toObject . ltsContext $ katipCtx) id
+getKatipLogger katipCtx = Logger (toObject . ltsContext $ katipCtx) mempty
   $ \ ctx stack s msg ->
     let ?callStack = stack
     in

--- a/src/Control/Logger/Katip.hs
+++ b/src/Control/Logger/Katip.hs
@@ -56,7 +56,7 @@ instance LogItem Object where
   payloadKeys _ _  = AllKeys
 
 getKatipLogger :: KatipContextTState -> Logger
-getKatipLogger katipCtx = Logger (toObject . ltsContext $ katipCtx)
+getKatipLogger katipCtx = Logger (toObject . ltsContext $ katipCtx) id
   $ \ ctx stack s msg ->
     let ?callStack = stack
     in

--- a/src/Control/Logger/Katip/Utils.hs
+++ b/src/Control/Logger/Katip/Utils.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE CPP #-}
 
 module Control.Logger.Katip.Utils
@@ -121,5 +120,5 @@ setLoggingCtx
   -> ReaderT r m a
 setLoggingCtx ctx' = local (part %~ go)
   where
-    go (Logger ctx f) =
-      Logger (ctx <> ctx') f
+    go (Logger ctx scrbber f) =
+      Logger (ctx <> ctx') scrbber f


### PR DESCRIPTION
This allows logger to have a log scrubbing function to be added for removing sensitive data.

It also does lexically scoped scrubbing, meaning that if you have a handler which takes in, say, a credit card number, you can feed the cc number (`censoring`) to the downstream logger and anything called from that handler will get that cc number scrubbed from any logs.