### PR TITLE
Clean up dependencies

### DIFF
--- a/control-logger.cabal
+++ b/control-logger.cabal
@@ -19,13 +19,13 @@ library
   exposed-modules:    Control.Logger.Internal
   build-depends:
     , aeson
-    , base
+    , base                  >=4.11
     , bytestring
     , control-has
     , control-has-katip
     , deepseq
     , exceptions
-    , fast-logger
+    , fast-logger           >=2.4.11
     , http-client
     , lens
     , monad-logger

--- a/control-logger.cabal
+++ b/control-logger.cabal
@@ -1,47 +1,55 @@
-cabal-version:       2.4
-name:                control-logger
-version:             0.1.0.0
-synopsis: Logger used by all projects
-license-file:        LICENSE
-build-type:          Simple
+cabal-version: 2.4
+name:          control-logger
+version:       0.1.0.0
+synopsis:      Logger used by all projects
+license-file:  LICENSE
+build-type:    Simple
 
 library
-  hs-source-dirs:      src
-  ghc-options:         -Wall
+  hs-source-dirs:     src
+  ghc-options:        -Wall
+
   if !impl(ghcjs)
-    exposed-modules:  Control.Logger
-                      Control.Logger.Katip
-                      Control.Logger.Katip.Utils
-                      Control.Logger.Orphans
-  exposed-modules:     Control.Logger.Internal
-  build-depends:       base
-                     , aeson
-                     , bytestring
-                     , control-has
-                     , control-has-katip
-                     , deepseq
-                     , exceptions
-                     , fast-logger
-                     , http-client
-                     , lens
-                     , monad-logger
-                     , mtl
-                     , shakespeare
-                     , text
-                     , time
-                     , unordered-containers
+    exposed-modules:
+      Control.Logger
+      Control.Logger.Katip
+      Control.Logger.Katip.Utils
+      Control.Logger.Orphans
+
+  exposed-modules:    Control.Logger.Internal
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , control-has
+    , control-has-katip
+    , deepseq
+    , exceptions
+    , fast-logger
+    , http-client
+    , lens
+    , monad-logger
+    , mtl
+    , shakespeare
+    , text
+    , time
+    , unordered-containers
+
   if !impl(ghcjs)
-    build-depends:     katip >= 0.8.8.0
-                     , optparse-applicative
-  default-language:    Haskell2010
-  default-extensions:  RankNTypes
-                       DataKinds
-                       FlexibleContexts
-                       FlexibleInstances
-                       LambdaCase
-                       OverloadedStrings
-                       ScopedTypeVariables
-                       DeriveGeneric
-                       ConstraintKinds
-                       RecordWildCards
-                       TypeSynonymInstances
+    build-depends:
+      , katip                 >=0.8.8.0
+      , optparse-applicative
+
+  default-language:   Haskell2010
+  default-extensions:
+    ConstraintKinds
+    DataKinds
+    DeriveGeneric
+    FlexibleContexts
+    FlexibleInstances
+    LambdaCase
+    OverloadedStrings
+    RankNTypes
+    RecordWildCards
+    ScopedTypeVariables
+    TypeSynonymInstances

--- a/src/Control/Logger.hs
+++ b/src/Control/Logger.hs
@@ -44,7 +44,9 @@ import           Control.Has
 import           Control.Lens hiding (censoring)
 import           Control.Logger.Internal
 import           Control.Logger.Orphans  ()
+import           Control.Monad
 import           Control.Monad.Catch
+import           Control.Monad.IO.Class
 import qualified Data.List               as List
 import           Data.Monoid
 import           Data.Text               (Text)
@@ -54,11 +56,6 @@ import           GHC.Stack
 import           Katip                   (ToObject (..))
 import           System.Log.FastLogger
 import           Text.Shakespeare.Text   (st)
--- import Control.Monad.RWS (censor)
-#if MIN_VERSION_mtl(2,3,0)
-import Control.Monad
-import Control.Monad.IO.Class
-#endif
 
 logError
   :: (LoggingMonad r m)

--- a/src/Control/Logger/Internal.hs
+++ b/src/Control/Logger/Internal.hs
@@ -16,14 +16,12 @@ module Control.Logger.Internal
 
 import Control.Has
 import Control.Lens
+import Control.Monad.IO.Class
 import Control.DeepSeq
 import Data.Aeson (ToJSON, FromJSON, Object, Value(..))
 import Data.Text (Text)
 import Data.Monoid
 import GHC.Stack
-#if MIN_VERSION_mtl(2,3,0)
-import Control.Monad.IO.Class
-#endif
 
 
 data LogSeverity


### PR DESCRIPTION
I don't know what happened there with `MIN_VERSION_mtl(2,3,0)`, but it prevented compilation on older GHCs, removing it fixes compilation, and I don't get any unused import warnings, across all GHC and mtl versions.

The package now builds against all dependency versions that can be planned, given the fixes in this PR:
- `base >=4.11` (GHC >=8.4) because in GHC 8.2, `Data.Monoid.<>` and `Data.Semigroup.<>` used to be different identifiers, and then became one identifier. This change is difficult to support and not worth it IMO.
- `fast-logger >=2.4.11` because that's when Show LogStr was introduced, which we use.